### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,12 @@
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "live"
+    allowed_updates:
+      - match:
+          update_type: "security"
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "all"


### PR DESCRIPTION
Dependabot is currently configured through the Dependabot GitHub App. I think it would be a good idea to bring this configuration into the repository itself