### PR TITLE
Wait for build success before dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,13 @@
 name: Dependabot auto-merge
 
-on: pull_request_target
+on:
+  workflow_run:
+    workflows:
+      - 'Python Package'
+    branches:
+      - 'dependabot/**'
+    types:
+      - completed
 
 permissions:
   pull-requests: write
@@ -9,7 +16,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata


### PR DESCRIPTION
All builds in the 'Python Package' workflow must complete successfully before the dependabot auto-merge can take place. Dependabot auto-merge workflow updated to reflect this dependency.