### PR TITLE
Use squash when auto-merging for Dependabot

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,6 +26,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Auto-merge Dependabot PR
-        run: gh pr merge --auto --merge ${{ github.event.workflow_run.head_branch }}
+        run: gh pr merge --auto --squash ${{ github.event.workflow_run.head_branch }}
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
UKHO repo settings require linear history, so squash Dependabot PR commits before merging